### PR TITLE
[버그수정] Windows 환경에서 서버 기동 시, 생기는 문제 개선

### DIFF
--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -145,7 +145,8 @@ export class Cyan {
   }
 
   private initHandler(controller: HttpController, route: RouteMetadataArgs) {
-    const path = this.settings.os ? route.path : resolve(this.settings.basePath || "/", route.path);
+    const basePath = this.settings.basePath?.endsWith("/") ? this.settings.basePath.slice(0, -1) : this.settings.basePath || "";
+    const path = (basePath => (route.path.startsWith("/") ? `${basePath}${route.path}` : `${basePath}/${route.path}`))(basePath);
 
     this.logger.info(`[router] ${route.action} ${path} - ${route.target.name}.${route.method}`);
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -27,6 +27,7 @@ export enum Stage {
 }
 
 export interface CyanSettings {
+  os?: "Windows_NT" | undefined;
   stage?: Stage;
   name?: string;
   port?: number;
@@ -144,7 +145,7 @@ export class Cyan {
   }
 
   private initHandler(controller: HttpController, route: RouteMetadataArgs) {
-    const path = resolve(this.settings.basePath || "/", route.path);
+    const path = this.settings.os ? route.path : resolve(this.settings.basePath || "/", route.path);
 
     this.logger.info(`[router] ${route.action} ${path} - ${route.target.name}.${route.method}`);
 


### PR DESCRIPTION
# 해당 이슈
- 'maven-crfs' repo를 Mac과 다른 Windows 환경에서 환경설정 및 서버를 가동하려고 하였을 때, 호환 문제가 생기는 것을 확인
```
<Windows 환경 호환 문제>
1. 빌드를 위한 .NET 프레임워크와 python 문제
  > powershell을 관리자 권한으로 실행 후,
    > 'npm update' 실행
    > 'npm i' 실행

2. pakage.json >>> start:dev의 값이 ''를 사용했을 때, ``로 한번 더 감싸져서 명령어를 잘못 인식
  > windows용 실행 스크립트 생성
  > OS가 windows면 process.argv로 process.env에 변수가 할당되는 코드 추가

3. coralblack에서 path 관련 regexp 오류 발생
  > Application.js의 initHandler에서 path를 정의할 때, path.resolve 함수가 절대경로를 반환해주고 있음. 이 경우 윈도우는 'C:\'가 앞에 추가로 붙기 때문에 regexp 오류 발생
  > OS가 windows면 route.path만으로 설정되도록 코드 변경
```
> 4/15, 4/17, 4/18 진행
> https://curving.io/issues/224
> https://curving.io/issues/232

# 설명
- Windows에서 서버 기동 시, path.resolve에 의해 절대 경로인 'C:\'가 붙으면서 생기는 오류 수정

## PR 종류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 기존 기능 개선
- [ ] 리팩토링
- [ ] 개발 환경 변경

## 기존 기능 영향도

- [ ] 없음
- [x] 영향도 낮음
- [ ] 영향도 높음 (기존 담당자 코드 리뷰 필수)

## 테스트

- [x] Manual 테스트 완료
- [ ] Unit Test 코드 작성
- [ ] Integration Test 코드 작성

## 체크리스트

- [ ] 정적분석 도구 (Lint) 검증 완료
- [x] 코드 셀프-리뷰 완료
- [ ] NOTE 주석 포함
- [ ] TODO 주석 포함
- [ ] 관련 문서 업데이트 완료
- [ ] 의존성 모듈 선반영 여부 확인 완료
